### PR TITLE
refactor: improve function parameters and data extraction

### DIFF
--- a/src/laphw/cli.py
+++ b/src/laphw/cli.py
@@ -1,36 +1,49 @@
+from pprint import pprint
+
 import typer
 from rich.console import Console
 
+from . import file_tree_parser
+
+ALL_DOCUMENTS = file_tree_parser.get_all_documents()
+FILE_TREE_DATA = file_tree_parser.get_file_tree_data(all_documents=ALL_DOCUMENTS)
+
+available_distributions = ", ".join(
+    file_tree_parser.get_all_distributions(all_documents=ALL_DOCUMENTS)
+)
+available_brands = ", ".join(file_tree_parser.get_all_brands(ALL_DOCUMENTS))
+available_models = ", ".join(file_tree_parser.get_all_models(ALL_DOCUMENTS))
+available_fixes = ", ".join(file_tree_parser.get_all_fixes(ALL_DOCUMENTS))
+
 app = typer.Typer(help="A CLI tool for accessing Linux laptop hardware fixes")
 console = Console()
-# all_fixes = get_fixes_documents().fix_file_paths
 
 
 @app.command()  # type: ignore[misc]
 def main(
     distribution: str | None = typer.Option(
-        None, "--dist", "-d", help="Distribution: arch, opensuse, ubuntu"
+        None, "--dist", "-d", help=f"Available distributions: {available_distributions}"
     ),
     brand: str | None = typer.Option(
-        None, "--brand", "-b", help="Brand (dell, lenovo, framework, hp)"
+        None, "--brand", "-b", help=f"Available brands: {available_brands}"
     ),
     model: str | None = typer.Option(
-        None, "--model", "-m", help="Model (xps-13-9370, framework13, thinkpad-x1)"
+        None, "--model", "-m", help=f"Available models: {available_models}"
     ),
     hardware: str | None = typer.Option(
         None,
         "--hardware",
         "-hw",
-        help="Hardware (audio, bluetooth, suspend, graphics, wifi, power, touchpad, fingerprint)",
+        help=f"Available hardware fixes: {available_fixes}",
     ),
 ) -> None:
     if not any([distribution, brand, model, hardware]):
         typer.echo("Please specify at least one filter: --dist, --brand, or --model")
         raise typer.Exit(1)
 
-    # fixes: set[Path] = set(all_fixes)
-    # if distribution:
-    #     fixes = get_brand_model_distribution(distribution, set(all_fixes))
+    if distribution:
+        fixes = file_tree_parser.get_fixes_by_distribution(distribution, FILE_TREE_DATA)
+        pprint(fixes)
     # if brand:
     #     fixes = get_brand_model_distribution(brand, set(fixes))
     # if model:


### PR DESCRIPTION
BREAKING CHANGES:
- All query functions now require explicit parameters instead of internal calls
- get_file_tree_data() and get_all_*() functions require all_documents parameter

ADDED:
- get_all_brands() function for extracting unique brand names
- get_all_models() function for extracting unique model names
- get_all_fixes() function for extracting all fix names
- FILE_PATH_WITH_DIST_BRAND_MODEL constant for path length validation
- Dynamic CLI help text showing available options from parsed data

IMPROVED:
- CLI shows actual available distributions, brands, models, and fixes in help
- Better separation of concerns between data loading and data querying
- Consistent parameter ordering across all query functions
- Added TODO comment for potential safety issue in get_brand_by_model()

FIXED:
- "common" directories properly filtered out from distributions and brands
- Path length validation using named constant instead of magic number
- Removed global function calls that caused tight coupling

TECHNICAL CHANGES:
- CLI pre-loads ALL_DOCUMENTS and FILE_TREE_DATA at module level
- All query functions now accept FileTreeData parameter explicitly
- Improved comma-separated help text formatting in CLI options